### PR TITLE
fix: always add hashes to filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ export default async function makeWebpackConfig({
           Boolean
         ),
       },
-      immutableAssets: !watch,
+      immutableAssets: true,
       plugins: [
         new webpack.DefinePlugin({
           ...define,
@@ -363,7 +363,7 @@ export default async function makeWebpackConfig({
         }),
         new AssetsPlugin(path.join(paths.build, 'assets.json')),
         new MiniCssExtractPlugin({
-          filename: watch ? '[name].css' : '[name].[contenthash].css',
+          filename: '[name].[contenthash].css',
         }),
       ]
         .concat(process.stdout.isTTY ? [new webpack.ProgressPlugin()] : [])


### PR DESCRIPTION
That way it's very easy to invalidate service workers even in dev, when importing assets.json, because it changes service worker script contents.