### PR TITLE
fix: `strictExportPresence` -> `parser.javascript.exportsPresence`

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,7 +317,11 @@ function makeConfig({
       extensions: ['.js', '.ts', '.tsx'],
     },
     module: {
-      strictExportPresence: true,
+      parser: {
+        javascript: {
+          exportsPresence: 'error',
+        },
+      },
       rules: [
         {
           test: /\.js$/,


### PR DESCRIPTION
`strictExportPresence` is deprecated since
[v5.17.0](https://github.com/webpack/webpack/releases/tag/v5.17.0)

See https://github.com/webpack/webpack/commit/013ca3bdd7caeed139fe15f54a01004b652b8925#diff-4071bbceb2f239cf48da48d19fd9b724509294980b4142a5a75e9a6478009498